### PR TITLE
Update README for additional runtime env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ and stop with `make stop-local`.
 Please contact a FlowEHR admin to deploy to the FlowEHR infrastructure where a 
 managed repository will be created with credentials to deploy to the cloud.
 
-To add runtime environment variables into your app follow the [example diff](https://github.com/UCLH-Foundry/Dash-Seedling/compare/335ba5c85d8ec9c1e1ecaf32d86fb1c9b96e37a4...15fa63f6f9a62bfece8f35b1ee5c321b3ce22973) to add a connection string stored as a GitHub secret or variable. This must be performed by a code owner.
+To add runtime environment variables into your app follow the [example diff](https://github.com/UCLH-Foundry/Dash-Seedling/compare/335ba5c85d8ec9c1e1ecaf32d86fb1c9b96e37a4...15fa63f6f9a62bfece8f35b1ee5c321b3ce22973) to, for example, add a connection string stored as a GitHub secret or variable. This must be performed by a code owner.

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ and stop with `make stop-local`.
 
 Please contact a FlowEHR admin to deploy to the FlowEHR infrastructure where a 
 managed repository will be created with credentials to deploy to the cloud.
+
+To add runtime environment variables into your app follow the [example diff](https://github.com/UCLH-Foundry/Dash-Seedling/compare/335ba5c85d8ec9c1e1ecaf32d86fb1c9b96e37a4...15fa63f6f9a62bfece8f35b1ee5c321b3ce22973) to add a connection string stored as a GitHub secret or variable. This must be performed by a code owner.


### PR DESCRIPTION
## Resolves https://github.com/UCLH-Foundry/FlowEHR/issues/184

Updates the documentation with an example of how to add a runtime environment variable into the container. Connecting from local would mean putting the appropriate secret/var into `.env` for local development.

Possible extensions: keyvault, but requires some thought about how to manage (a) access for developers and (b) versions across app (i.e. GitHub) environments

### TODO

- [x] Test

works nicely:
<img width="1000" alt="Screenshot 2023-04-03 at 16 11 58" src="https://user-images.githubusercontent.com/39765193/229552232-b78451f7-1ccc-4fdb-bd41-44b632cce965.png">
<img width="1000" alt="Screenshot 2023-04-03 at 16 11 54" src="https://user-images.githubusercontent.com/39765193/229552248-410dade7-32d1-4155-a1ca-26d36461f937.png">
<img width="1000" alt="Screenshot 2023-04-03 at 16 11 17" src="https://user-images.githubusercontent.com/39765193/229552259-9f646c97-b6da-4c09-9de6-6e7cee9019aa.png">
