### PR TITLE
Cache apt and pip install commands

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -17,9 +17,6 @@ FROM python:3.10.10-bullseye
 # Create and run commands in /app inside the container
 WORKDIR /app
 
-# Copy the required files into the working directory
-COPY . /app/
-
 # Install the odbc Drivers to access the database
 RUN apt-get update && apt-get install -y --no-install-recommends locales apt-transport-https \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -31,6 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends locales apt-tra
     && apt-get -y --no-install-recommends install unixodbc-dev libodbc1 \
     && ACCEPT_EULA=Y apt-get -y --no-install-recommends install msodbcsql18
 
+# Get requirements for pip install
+COPY requirements.txt /app/
+
 # Install the Python dependencies
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --upgrade pip && \
@@ -39,6 +39,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Create and use a non-root user
 RUN useradd -m appUser
 USER appUser
+
+# Copy the required files into the working directory
+COPY . /app/
 
 # Serve the app on port 8000
 CMD gunicorn --bind 0.0.0.0:8000 app:server


### PR DESCRIPTION
Use docker build cache to save apt/pip install runs before copying to avoid installing everything from scratch on each serve-local run. (#14)

Reduces build time from over a minute to ~5 seconds.