### PR TITLE
Add mssql driver into devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,32 +2,21 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Dash Seedling",
-	"build": {
-		"dockerfile": "../app/Dockerfile",
-		"context": "../app/"
-	},
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 	"ghcr.io/devcontainers/features/azure-cli:1": {
 			"version": "2.44.1"
 		},
-	"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+	"ghcr.io/jlaundry/devcontainer-features/mssql-odbc-driver:1": {
+		"version": "18"
+	}
 	},
 
 	// Configure customizations for VSCode
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"terminal.integrated.profiles.linux": {
-					"bash": {
-					  "path": "/bin/bash",
-					  "overrideName": true
-					}
-				  },
-				  "terminal.integrated.defaultProfile.linux": "bash"
-			}
-		}
-	}
+	"customizations": {}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,11 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Dash Seedling",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
-
+	"build": {
+		"dockerfile": "../app/Dockerfile",
+		"context": "../app/"
+	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 	"features": {
 	"ghcr.io/devcontainers/features/azure-cli:1": {
 			"version": "2.44.1"
@@ -14,15 +14,24 @@
 	"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 
+	// Configure customizations for VSCode
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"terminal.integrated.profiles.linux": {
+					"bash": {
+					  "path": "/bin/bash",
+					  "overrideName": true
+					}
+				  },
+				  "terminal.integrated.defaultProfile.linux": "bash"
+			}
+		}
+	}
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r app/requirements.txt"
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+	// "postCreateCommand": ""
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,12 +15,15 @@
 	}
 	},
 
-	// Configure customizations for VSCode
-	"customizations": {}
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": ""
+	"postCreateCommand": "pip3 install --user -r app/requirements.txt"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }


### PR DESCRIPTION
## Resolves #13 

~Uses the app image as the base for the devcontainer. Means requirements aren't duplicated. I am however keen to still support development outside a devcontainer and running inside the VSCode ecosystem~
