### PR TITLE
Remove unnecessary userID

### DIFF
--- a/.env.dev.sample
+++ b/.env.dev.sample
@@ -2,7 +2,7 @@ APP_NAME=seedling
 DEBUG=True
 LOCAL_APP_PORT=8050
 LOCAL_IMAGE_NAME=flowehr_seedling_app
-FEATURE_STORE_CONNECTION_STRING="Driver={ODBC Driver 18 for SQL Server};Server=tcp:__CHANGE_ME__.database.windows.net,1433;Database=sql-db-features;Uid=__CHANGE_ME__;Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30"
+FEATURE_STORE_CONNECTION_STRING="Driver={ODBC Driver 18 for SQL Server};Server=tcp:__CHANGE_ME__.database.windows.net,1433;Database=sql-db-features;Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30"
 COSMOSDB_ENDPOINT="https://__CHANGE_ME__.documents.azure.com:443/"
 
 # Optional: 


### PR DESCRIPTION
Having a section for a user ID that is not required will just confuse people.

→ Remove to help onboarding of new data scientists/app developers.