### PR TITLE
Fix broken local serve due to azure logging middleware failure

### DIFF
--- a/app/azure_logging.py
+++ b/app/azure_logging.py
@@ -65,6 +65,11 @@ def initialize_logging(
     logger = logging.getLogger()
     logging.basicConfig(level=logging_level, format="%(asctime)s %(message)s")
 
+    ai_conn_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING")
+    if (ai_conn_string is None or ai_conn_string == ""):
+        logger.info(f"APPLICATIONINSIGHTS_CONNECTION_STRING unset or empty. Azure logging will not be enabled.")
+        return;
+
     try:
         # picks up os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"] automatically
         azurelog_handler = AzureLogHandler()
@@ -72,11 +77,8 @@ def initialize_logging(
         azurelog_handler.addFilter(ExceptionTracebackFilter())
         logger.addHandler(azurelog_handler)
     except ValueError as e:
-        if os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING") is None:
-            logger.info(f"Application Insights logger handler not set")
-        else:
-            logger.error(f"Failed to set Application Insights logger handler: {e}")
-            raise e
+        logger.error(f"Failed to set Application Insights logger handler: {e}")
+        raise e
 
     config_integration.trace_integrations(["logging"])
     Tracer(sampler=AlwaysOnSampler())

--- a/app/azure_logging.py
+++ b/app/azure_logging.py
@@ -68,7 +68,7 @@ def initialize_logging(
     ai_conn_string = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING")
     if (ai_conn_string is None or ai_conn_string == ""):
         logger.info(f"APPLICATIONINSIGHTS_CONNECTION_STRING unset or empty. Azure logging will not be enabled.")
-        return;
+        return
 
     try:
         # picks up os.environ["APPLICATIONINSIGHTS_CONNECTION_STRING"] automatically


### PR DESCRIPTION
Fixes #28 

When docker compose is used (for `serve-local`), it sets any unset variables as empty strings in the container environment. So, as would be typical for local scenarios not using application insights, when unset, the logging initialisation fails as it only catches for the env var being `None`, when it also needs to catch for empty strings.

Have amended with a check before the logging is initialised, which will skip if the `APPLICATIONINSIGHTS_CONNECTION_STRING` is `None` or `""`, logging a warning message to the console if so